### PR TITLE
escape string for insert values

### DIFF
--- a/lib/fluent/plugin/out_pghstore.rb
+++ b/lib/fluent/plugin/out_pghstore.rb
@@ -54,7 +54,7 @@ class Fluent::PgHStoreOutput < Fluent::BufferedOutput
   def generate_sql(tag, time, record)
     kv_list = []
     record.each {|(key,value)|
-      kv_list.push("\"#{key}\" => \"#{value}\"")
+      kv_list.push("\"#{conn.escape_str(key)}\" => \"#{conn.escape_str(value)}\"")
     }
 
     tag_list = tag.split(".")

--- a/lib/fluent/plugin/out_pghstore.rb
+++ b/lib/fluent/plugin/out_pghstore.rb
@@ -54,7 +54,7 @@ class Fluent::PgHStoreOutput < Fluent::BufferedOutput
   def generate_sql(tag, time, record)
     kv_list = []
     record.each {|(key,value)|
-      kv_list.push("\"#{conn.escape_str(key)}\" => \"#{conn.escape_str(value)}\"")
+      kv_list.push("\"#{conn.escape_string(key)}\" => \"#{conn.escape_string(value)}\"")
     }
 
     tag_list = tag.split(".")


### PR DESCRIPTION
Original code does not escape any strings, so it can cause SQL Injection or execute unexpected SQL statement.
Add Pg#escape_string() in generate_sql to fix these problems.

