### PR TITLE
Add a secret parameter

### DIFF
--- a/lib/fluent/plugin/out_pghstore.rb
+++ b/lib/fluent/plugin/out_pghstore.rb
@@ -6,7 +6,7 @@ class Fluent::PgHStoreOutput < Fluent::BufferedOutput
   config_param :host, :string, :default => 'localhost'
   config_param :port, :integer, :default => 5432
   config_param :user, :string, :default => nil
-  config_param :password, :string, :default => nil
+  config_param :password, :string, :default => nil, :secret => true
 
   config_param :table_option, :string, :default => nil
 


### PR DESCRIPTION
Fluentd 0.12.13 or later supports secret parameter feature.
https://github.com/fluent/fluentd/blob/4e3a4ecb/ChangeLog#L34

This feature works as below:

```log
  <match apache.*>
    type pghstore
    database test
    user pguser
    password xxxxxx
    table test
    table_option CREATE INDEX time_index ON testb (time);
  </match>
</ROOT>
```