### PR TITLE
Add missing license entry in gemspec

### DIFF
--- a/fluent-plugin-pghstore.gemspec
+++ b/fluent-plugin-pghstore.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/shirou/fluent-plugin-pghstore"
   s.summary     = %q{Output to PostgreSQL database which has a hstore extension}
   s.description = %q{Output to PostgreSQL database which has a hstore extension}
+  s.license     = "Apache-2.0"
 
   s.rubyforge_project = "fluent-plugin-pghstore"
 


### PR DESCRIPTION
This change can show license information on rubygems.org