### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/fluent-plugin-pghstore.gemspec
+++ b/fluent-plugin-pghstore.gemspec
@@ -21,10 +21,9 @@ Gem::Specification.new do |s|
   # specify any dependencies here; for example:
   s.add_development_dependency "rspec", "~> 3.2.0"
   # s.add_runtime_dependency "rest-client"
-  s.add_development_dependency "fluentd", [">= 0.12.5", "< 2"]
   s.add_development_dependency "pg", "~> 0.18.1"
   s.add_development_dependency "rake", ">= 11.0"
   s.add_development_dependency "test-unit", "~> 3.1.0"
-#  s.add_runtime_dependency "fluentd", "~> 0.12.5"
+  s.add_runtime_dependency "fluentd", [">= 0.14.0", "< 2"]
 #  s.add_runtime_dependency "pg", "~> 0.18.1"
 end

--- a/lib/fluent/plugin/out_pghstore.rb
+++ b/lib/fluent/plugin/out_pghstore.rb
@@ -65,7 +65,7 @@ class Fluent::Plugin::PgHStoreOutput < Fluent::Plugin::Output
       begin
         conn.exec(sql)
       rescue PGError => e
-        $log.error "PGError: " + e.message  # dropped if error
+        log.error "PGError: " + e.message  # dropped if error
       end
     }
 
@@ -116,7 +116,7 @@ SQL
         @conn = PG.connect(:dbname => @database, :host => @host, :port => @port)
       end
     rescue PGError => e
-      $log.error "Error: could not connect database:" + @database
+      log.error "Error: could not connect database:" + @database
       return nil
     end
 
@@ -150,12 +150,12 @@ SQL
     begin
       conn.exec(sql)
     rescue PGError => e
-      $log.error "Error at create_table:" + e.message
-      $log.error "SQL:" + sql
+      log.error "Error at create_table:" + e.message
+      log.error "SQL:" + sql
     end
     conn.close
 
-    $log.warn "table #{tablename} was not exist. created it."
+    log.warn "table #{tablename} was not exist. created it."
   end
 
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -12,6 +12,8 @@ require 'test/unit'
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'fluent/test'
+require 'fluent/test/driver/output'
+require 'fluent/test/helpers'
 unless ENV.has_key?('VERBOSE')
   nulllogger = Object.new
   nulllogger.instance_eval {|obj|


### PR DESCRIPTION
Hi, I've tried to migrate to use v0.14 API.
Note that this patches depend on Fluentd v0.14 at runtime.
So, please review carefully and follow this v0.14 guideline: http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12

Thanks,