### PR TITLE
Fix quoting using hstore function

### DIFF
--- a/lib/fluent/plugin/out_pghstore.rb
+++ b/lib/fluent/plugin/out_pghstore.rb
@@ -89,7 +89,7 @@ SQL
   def generate_sql(conn, tag, time, record)
     kv_list = []
     record.each {|(key,value)|
-      kv_list.push("\"#{conn.escape_string(key.to_s)}\" => \"#{conn.escape_string(value.to_s)}\"")
+      kv_list.push("hstore(E'#{conn.escape_string(key.to_s)}',E'#{conn.escape_string(value.to_s)}')")
     }
 
     tag_list = tag.split(".")
@@ -97,7 +97,7 @@ SQL
 
     sql =<<"SQL"
 INSERT INTO #{@table} (tag, time, record) VALUES
-(ARRAY[#{tag_list.join(",")}], '#{Time.at(time)}'::TIMESTAMP WITH TIME ZONE, E'#{kv_list.join(",")}');
+(ARRAY[#{tag_list.join(",")}], '#{Time.at(time)}'::TIMESTAMP WITH TIME ZONE, #{kv_list.join("||")});
 SQL
 
     return sql


### PR DESCRIPTION
I found that entries that have double quotes returned errors, checking the code I realized that the problem was that the function con.escape_string escapes only single quotes, leaving the double quotes unescaped. Thinking about the problem I concluded that the best solution is to avoid completely the use of double quotes and use the Postgresql hstore function to create the key value pairs and join them together using a double pipe ||. This way the escaping function does its work as it is escaping a single quoted string literal.